### PR TITLE
Switch to official repo for recursive-readdir

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "has-generators": "^1.0.1",
     "is": "^2.2.0",
     "is-utf8": "~0.2.0",
-    "recursive-readdir": "git+https://github.com/stellar/recursive-readdir.git",
+    "recursive-readdir": "git+https://github.com/jergason/recursive-readdir.git",
     "rimraf": "^2.2.8",
     "stat-mode": "^0.2.0",
     "thunkify": "^2.1.2",


### PR DESCRIPTION
This still isn't the current release because the fix for our issue hasn't been published yet. We should change this again once it's released: https://github.com/jergason/recursive-readdir/pull/33

(Also, parent issue in metalsmith; we can remove this entire repo when that is fixed and released: https://github.com/metalsmith/metalsmith/pull/229)